### PR TITLE
BoastDetailView 레이아웃 변경 사항 수정 완료 

### DIFF
--- a/DeulLangNalLang/DeulLangNalLang/Sources/View/AwardTab/Detail/BoastDetailView.swift
+++ b/DeulLangNalLang/DeulLangNalLang/Sources/View/AwardTab/Detail/BoastDetailView.swift
@@ -16,20 +16,43 @@ struct BoastDetailView: View {
             ZStack{
                 RoundedRectangle(cornerRadius: 20)
                     .frame(width: 329, height: 480)
-                    .foregroundColor(.blue)
+                    .foregroundColor(.DNBlue)
+                    .shadow(radius: 5, x: 3, y: 3)
+
                 VStack(spacing: 0){
-                    //---------- 사진 1장일 때--------------
-//                    Image("선인장")
+                    //---------- 사진 0장일 때 --------------
+//                    Text("오늘 들이가 배고프다고 해서 새로운 메뉴 파스타에 도전해봤다. 생각보다 쉽고 맛있었다. 다행히 들이도 맛있게 먹어준 것 같아서 좋았다. 오늘 들이가 배고프다고 해서 새로운 메뉴이다.")
+//                        .font(.bodyRegular)
+//                        .frame(width: 281, height: 152, alignment: .topLeading)
+//                        .padding(.top, 20)
+//                    Spacer()
+//                    Text("2024년 5월 5일")
+//                        .font(.bodyEmphasized)
+//                        .frame(width: 281, alignment: .leading)
+//                        .padding(.bottom, 22)
+                    
+                    //---------- 사진 1장일 때 --------------
+//                    Image("awardOrigami")
 //                        .resizable()
 //                        .aspectRatio(contentMode: .fill)
 //                        .frame(width: 281, height: 220)
 //                        .clipped()
 //                        .cornerRadius(8)
 //                        .padding(.top, 20)
+//                    
+//                    Text("오늘 들이가 배고프다고 해서 새로운 메뉴 파스타에 도전해봤다. 생각보다 쉽고 맛있었다. 다행히 들이도 맛있게 먹어준 것 같아서 좋았다. 오늘 들이가 배고프다고 해서 새로운 메뉴이다.")
+//                        .font(.bodyRegular)
+//                        .frame(width: 281, height: 152, alignment: .topLeading)
+//                        .padding(.vertical, 22)
+//                    
+//                    Text("2024년 5월 5일")
+//                        .font(.bodyEmphasized)
+//                        .frame(width: 281, alignment: .leading)
+//                    Spacer()
                     
-                    //---------- 사진 2장일 때--------------
+                    //---------- 사진 2장일 때 --------------
                     HStack(spacing: 0){
-                        Image("선인장")
+                        Image("awardGem")
                             .resizable()
                             .aspectRatio(contentMode: .fill)
                             .frame(width: 136, height: 220)
@@ -38,7 +61,7 @@ struct BoastDetailView: View {
                             .padding(.top, 20)
                             .padding(.horizontal, 5)
 
-                        Image("선인장")
+                        Image("awardOctopus")
                             .resizable()
                             .aspectRatio(contentMode: .fill)
                             .frame(width: 136, height: 220)
@@ -46,21 +69,26 @@ struct BoastDetailView: View {
                             .cornerRadius(8)
                             .padding(.top, 20)
                             .padding(.horizontal, 5)
-
                     }
-                    
                     Text("오늘 들이가 배고프다고 해서 새로운 메뉴 파스타에 도전해봤다. 생각보다 쉽고 맛있었다. 다행히 들이도 맛있게 먹어준 것 같아서 좋았다. 오늘 들이가 배고프다고 해서 새로운 메뉴이다.")
                         .font(.bodyRegular)
                         .frame(width: 281, height: 152, alignment: .topLeading)
                         .padding(.vertical, 22)
+                    
                     Text("2024년 5월 5일")
                         .font(.bodyEmphasized)
                         .frame(width: 281, alignment: .leading)
                     Spacer()
+                    //------------------------------------
+                    
                 }
             }
             .frame(width: 329, height: 480)
-            .padding(.bottom, 59)
+            
+            Text("터치해서 뒷면의 자랑을 확인해바라기!")
+                .font(.caption1Regular)
+                .foregroundColor(.gray)
+                .padding(.top, 32)
         }
         .navigationTitle("상장과 자랑 보기")
         .navigationBarBackButtonHidden(true)


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) resolved: #이슈번호, #이슈번호, ...

resolved: #45 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

보스트 디테일 뷰의 자랑 레이아웃 디자인이 변경되었는데요,
이에 맞추어 코드 상의 레이아웃 변경을 완료하였습니다.

추가로 카드 아래의 UX Writing과 카드의 그림자도 추가하였고,
아래로 치우쳐 있던 카드를 가운데 정렬로 수정하였습니다.

### 스크린샷 (선택)

<img width="279" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/2024-MC2-M16-DeulLangNalLang/assets/167423022/28d0479c-2658-46cb-83b8-995f5a1ca20f">


## 💬리뷰 요구사항 및 논의할 거리(선택)

> - 리뷰어가 확인했으면 하는 부분이 있다면 작성해주세요

> - 구현 과정에서 팀 내 논의가 이뤄져야 할 부분이나 궁금하거나 알고 있어야 사항이 있다면 작성해주세요
