### PR TITLE
BoastCard 프레임에 맞게 사진 조정

### DIFF
--- a/DeulLangNalLang/DeulLangNalLang/Sources/View/BoastTab/BoastCardView.swift
+++ b/DeulLangNalLang/DeulLangNalLang/Sources/View/BoastTab/BoastCardView.swift
@@ -6,7 +6,7 @@ struct BoastCardView: View {
     @State private var Username = "Deul"
     @State private var images: [String] = [
         "https://i.pinimg.com/564x/1e/a8/1f/1ea81fe0ddc6b0dbd76899c7aebfb47c.jpg",
-        //        "https://i.pinimg.com/564x/8a/be/9b/8abe9b3640dbef426f6c9c9a67457e9d.jpg"
+        "https://i.pinimg.com/564x/8a/be/9b/8abe9b3640dbef426f6c9c9a67457e9d.jpg"
     ]
     
     @State private var showSheet: Bool = false
@@ -34,18 +34,20 @@ struct BoastCardView: View {
                     } placeholder: {
                         Color.red
                     }
-                    .frame(height: 180)
-                    .aspectRatio(contentMode: .fit)
+                    .aspectRatio(contentMode: .fill)
+                    .frame(height: 180, alignment: .center)
                     .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .clipped()
                     
                     AsyncImage(url: URL(string: images[1])) { image in
                         image.resizable()
                     } placeholder: {
                         Color.red
                     }
-                    .frame(height: 180)
-                    .aspectRatio(contentMode: .fit)
+                    .aspectRatio(contentMode: .fill)
+                    .frame(height: 180, alignment: .center)
                     .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .clipped()
                 }
             }
             


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) resolved: #이슈번호, #이슈번호, ...

resolved: #57 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 한장이던 두장이던.. 이제 사진이 찌부되지 않습니다 하하

<img width="349" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/2024-MC2-M16-DeulLangNalLang/assets/64794813/bf6a6708-c050-4d71-aca6-151c118afe03">
<img width="342" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/2024-MC2-M16-DeulLangNalLang/assets/64794813/0a2cb0fb-79e3-4f70-bac3-1e5a7f10abe5">

## 💬리뷰 요구사항 및 논의할 거리(선택)

> - 리뷰어가 확인했으면 하는 부분이 있다면 작성해주세요

> - 구현 과정에서 팀 내 논의가 이뤄져야 할 부분이나 궁금하거나 알고 있어야 사항이 있다면 작성해주세요
