### PR TITLE
플립 기능 버그 해결 및 플립 안내 메세지 플립 고정

### DIFF
--- a/DeulLangNalLang/DeulLangNalLang/Sources/View/AwardTab/Detail/AwardDetailView.swift
+++ b/DeulLangNalLang/DeulLangNalLang/Sources/View/AwardTab/Detail/AwardDetailView.swift
@@ -39,10 +39,10 @@ struct AwardDetailView: View {
                 }
             }
             .frame(width: 329, height: 480)
-            Text("터치해서 뒷면의 자랑을 확인해바라기!")
-                .font(.caption1Regular)
-                .foregroundColor(.gray)
-                .padding(.top, 32)
+//            Text("터치해서 뒷면의 자랑을 확인해바라기!")
+//                .font(.caption1Regular)
+//                .foregroundColor(.gray)
+//                .padding(.top, 32)
         }
     }
 }

--- a/DeulLangNalLang/DeulLangNalLang/Sources/View/AwardTab/Detail/BoastDetailView.swift
+++ b/DeulLangNalLang/DeulLangNalLang/Sources/View/AwardTab/Detail/BoastDetailView.swift
@@ -83,11 +83,10 @@ struct BoastDetailView: View {
                 }
             }
             .frame(width: 329, height: 480)
-            
-            Text("터치해서 뒷면의 자랑을 확인해바라기!")
-                .font(.caption1Regular)
-                .foregroundColor(.gray)
-                .padding(.top, 32)
+//            Text("터치해서 뒷면의 자랑을 확인해바라기!")
+//                .font(.caption1Regular)
+//                .foregroundColor(.gray)
+//                .padding(.top, 32)
         }
     }
 }

--- a/DeulLangNalLang/DeulLangNalLang/Sources/View/AwardTab/Detail/CardFlipView.swift
+++ b/DeulLangNalLang/DeulLangNalLang/Sources/View/AwardTab/Detail/CardFlipView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct CardFlipView: View {
     
+    
     @Environment(\.dismiss) var dismiss
     @State var isFlipped = false
     
@@ -21,33 +22,27 @@ struct CardFlipView: View {
                                           receiver: User(name: .San)))
     
     var body: some View {
-        Group{
-            if !isFlipped {
-                // scaleEffect를 적용하여 CardView를 반대로 뒤집어 둠.
-                // rotation3DEffect로 앞 -> 뒤로 뒤집으려 할 때 뒤에 있던 View가 뒤집어진 채로 보이기 때문.
-                BoastDetailView(boast: boast)
-            } else {
-                AwardDetailView(award: boast.award!)
+        VStack(spacing: 0) {
+            ZStack {
+                if isFlipped {
+                    BoastDetailView(boast: boast)
+                } else {
+                    AwardDetailView(award: boast.award!)
+                }
             }
-        }
-        .scaleEffect(x: isFlipped ? -1 : 1)
-        .cornerRadius(10)
-        .frame(width: 300,
-               height: 500)
-        .rotation3DEffect(
-            // 해당 각도로 만듦. 이때 UI가 자연스레 돌아가는 이유는 하단의 animation 덕분.
-            .degrees(isFlipped
-                     ? 180
-                     : 0),
-            // y축을 기준으로 돌리겠다는 의미
-            axis: (x: 0,
-                   y: 1,
-                   z: 0)
-        )
-        // 자연스럽게 '보이던 View'는 사라지고 '안보이던 View'는 나타나는 효과
-        .animation(.default, value: isFlipped)
-        .onTapGesture {
-            self.isFlipped.toggle()
+            .scaleEffect(x: isFlipped ? -1 : 1)
+            .frame(width: 200, height: 300)
+            .rotation3DEffect(.degrees(isFlipped ? 180 : 0), axis: (x: 0, y: -1, z: 0))
+            .animation(.easeInOut(duration: 0.6), value: isFlipped)
+            .onTapGesture {
+                isFlipped.toggle()
+            }
+            .frame(width: 329, height: 480)
+            
+            Text("터치해서 뒷면의 자랑을 확인해바라기!")
+                .font(.caption1Regular)
+                .foregroundColor(.gray)
+                .padding(.top, 32)
         }
         .navigationBarBackButtonHidden()
         .navigationTitle("상장과 자랑 보기")


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) resolved: #이슈번호, #이슈번호, ...

#12 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

느리게 터치하면 플립이 작동 안되는 버그를 수정하였습니다.
추가로 하단의 플립 안내 메세지도 함께 플립이 되는 것을 발견하여,
어워드 디테일 뷰, 보스트 디테일 뷰에 있는 텍스트를 삭제한 뒤, 플립 뷰에 적용하였습니다.

### 스크린샷 (선택)


## 💬리뷰 요구사항 및 논의할 거리(선택)

> - 리뷰어가 확인했으면 하는 부분이 있다면 작성해주세요

> - 구현 과정에서 팀 내 논의가 이뤄져야 할 부분이나 궁금하거나 알고 있어야 사항이 있다면 작성해주세요
