### PR TITLE
플립 카드 뒷면 자랑 레이아웃 사진 갯수 별 변화 적용

### DIFF
--- a/DeulLangNalLang/DeulLangNalLang/Sources/View/AwardTab/Detail/AwardDetailView.swift
+++ b/DeulLangNalLang/DeulLangNalLang/Sources/View/AwardTab/Detail/AwardDetailView.swift
@@ -39,10 +39,6 @@ struct AwardDetailView: View {
                 }
             }
             .frame(width: 329, height: 480)
-//            Text("터치해서 뒷면의 자랑을 확인해바라기!")
-//                .font(.caption1Regular)
-//                .foregroundColor(.gray)
-//                .padding(.top, 32)
         }
     }
 }

--- a/DeulLangNalLang/DeulLangNalLang/Sources/View/AwardTab/Detail/BoastDetailView.swift
+++ b/DeulLangNalLang/DeulLangNalLang/Sources/View/AwardTab/Detail/BoastDetailView.swift
@@ -10,6 +10,10 @@ import SwiftUI
 struct BoastDetailView: View {
     @Environment(\.dismiss) var dismiss
     @State private var isFavorite: Bool = false
+    @State private var images: [Image] = [Image(.awardOctopus), Image(.awardGem)]
+    
+    
+    
     var boast: Boast
     
     var body: some View {
@@ -19,74 +23,73 @@ struct BoastDetailView: View {
                     .frame(width: 329, height: 480)
                     .foregroundColor(.DNBlue)
                     .shadow(radius: 5, x: 3, y: 3)
-
+                
                 VStack(spacing: 0){
-                    //---------- 사진 0장일 때 --------------
-//                    Text("오늘 들이가 배고프다고 해서 새로운 메뉴 파스타에 도전해봤다. 생각보다 쉽고 맛있었다. 다행히 들이도 맛있게 먹어준 것 같아서 좋았다. 오늘 들이가 배고프다고 해서 새로운 메뉴이다.")
-//                        .font(.bodyRegular)
-//                        .frame(width: 281, height: 152, alignment: .topLeading)
-//                        .padding(.top, 20)
-//                    Spacer()
-//                    Text("2024년 5월 5일")
-//                        .font(.bodyEmphasized)
-//                        .frame(width: 281, alignment: .leading)
-//                        .padding(.bottom, 22)
+                    if images.count == 0 {
+                        Text("\(boast.contents)")
+                            .font(.bodyRegular)
+                            .frame(width: 281, height: 152, alignment: .topLeading)
+                            .padding(.top, 20)
+                        Spacer()
+                        Text("\(getDateFormat(date: boast.date))")
+                            .font(.bodyEmphasized)
+                            .frame(width: 281, alignment: .leading)
+                            .padding(.bottom, 22)
+                    }
                     
-                    //---------- 사진 1장일 때 --------------
-//                    Image("awardOrigami")
-//                        .resizable()
-//                        .aspectRatio(contentMode: .fill)
-//                        .frame(width: 281, height: 220)
-//                        .clipped()
-//                        .cornerRadius(8)
-//                        .padding(.top, 20)
-//                    
-//                    Text("오늘 들이가 배고프다고 해서 새로운 메뉴 파스타에 도전해봤다. 생각보다 쉽고 맛있었다. 다행히 들이도 맛있게 먹어준 것 같아서 좋았다. 오늘 들이가 배고프다고 해서 새로운 메뉴이다.")
-//                        .font(.bodyRegular)
-//                        .frame(width: 281, height: 152, alignment: .topLeading)
-//                        .padding(.vertical, 22)
-//                    
-//                    Text("2024년 5월 5일")
-//                        .font(.bodyEmphasized)
-//                        .frame(width: 281, alignment: .leading)
-//                    Spacer()
+                    if images.count == 1 {
+                        images[0]
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .frame(width: 281, height: 220)
+                            .clipped()
+                            .cornerRadius(8)
+                            .padding(.top, 20)
+                        
+                        Text("\(boast.contents)")
+                            .font(.bodyRegular)
+                            .frame(width: 281, height: 152, alignment: .topLeading)
+                            .padding(.vertical, 22)
+                        
+                        Text("\(getDateFormat(date: boast.date))")
+                            .font(.bodyEmphasized)
+                            .frame(width: 281, alignment: .leading)
+                        Spacer()
+                    }
                     
-                    //---------- 사진 2장일 때--------------
-//                    HStack(spacing: 0){
-//                        Image("선인장")
-//                            .resizable()
-//                            .aspectRatio(contentMode: .fill)
-//                            .frame(width: 136, height: 220)
-//                            .clipped()
-//                            .cornerRadius(8)
-//                            .padding(.top, 20)
-//                            .padding(.horizontal, 5)
-//
-//                        Image("선인장")
-//                            .resizable()
-//                            .aspectRatio(contentMode: .fill)
-//                            .frame(width: 136, height: 220)
-//                            .clipped()
-//                            .cornerRadius(8)
-//                            .padding(.top, 20)
-//                            .padding(.horizontal, 5)
-//
-//                    }
+                    if images.count == 2 {
+                        HStack(spacing: 0){
+                            images[0]
+                                .resizable()
+                                .aspectRatio(contentMode: .fill)
+                                .frame(width: 136, height: 220)
+                                .clipped()
+                                .cornerRadius(8)
+                                .padding(.top, 20)
+                                .padding(.horizontal, 5)
+                            
+                            images[1]
+                                .resizable()
+                                .aspectRatio(contentMode: .fill)
+                                .frame(width: 136, height: 220)
+                                .clipped()
+                                .cornerRadius(8)
+                                .padding(.top, 20)
+                                .padding(.horizontal, 5)
+                            
+                        }
+                        Text("\(boast.contents)")
+                            .font(.bodyRegular)
+                            .frame(width: 281, height: 152, alignment: .topLeading)
+                            .padding(.vertical, 22)
+                        Text("\(getDateFormat(date: boast.date))")
+                            .font(.bodyEmphasized)
+                            .frame(width: 281, alignment: .leading)
+                    }
                     
-                    Text("\(boast.contents)")
-                        .font(.bodyRegular)
-                        .frame(width: 281, height: 152, alignment: .topLeading)
-                        .padding(.vertical, 22)
-                    Text("\(getDateFormat(date: boast.date))")
-                        .font(.bodyEmphasized)
-                        .frame(width: 281, alignment: .leading)
                 }
             }
             .frame(width: 329, height: 480)
-//            Text("터치해서 뒷면의 자랑을 확인해바라기!")
-//                .font(.caption1Regular)
-//                .foregroundColor(.gray)
-//                .padding(.top, 32)
         }
     }
 }

--- a/DeulLangNalLang/DeulLangNalLang/Sources/View/AwardTab/Detail/CardFlipView.swift
+++ b/DeulLangNalLang/DeulLangNalLang/Sources/View/AwardTab/Detail/CardFlipView.swift
@@ -13,7 +13,7 @@ struct CardFlipView: View {
     @Environment(\.dismiss) var dismiss
     @State var isFlipped = false
     
-    @State var boast = Boast(contents: "오늘 들이가 배고프다고 해서 새로운 메뉴 파스타에 도전해봤다. 생각보다 쉽고 맛있었다. 다행히 들이도 맛있게 먹어준 것 같아서 좋았다. 오늘 들이가 배고프다고 해서 새로운 메뉴이다.",
+    @State var boast = Boast(contents: "오늘 들이가 배고프다고 해서 새로운 메뉴 파스타에 도전해봤다. 생각보다 쉽고 맛있었다. 다행히 들이도 맛있게 먹어준 것 같아서 좋았다. 오늘 들이가 배고프다고 해서 새로운 메뉴이다.", 
                              date: Date(),
                              award: Award(title: "우리집 요리왕",
                                           contents: "산이는 부모님이 집에 안계실 때 부모님을 대신하여 들이가 배고픈지 물어보고 맛있는 밥을 만들어 주었기에 이 상을 수여합니다.",


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) resolved: #이슈번호, #이슈번호, ...

#12 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

플립 카드 뒷면의 자랑 레이아웃을 사진 갯수에 따라 바뀌도록 수정하였습니다.
보스트 디테일 뷰 수정을 통해 플립 뷰의 보스트 면까지 연동됩니다.

### 스크린샷 (선택)

<img width="272" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/2024-MC2-M16-DeulLangNalLang/assets/167423022/1e77f389-bf87-4d2f-9cd6-1ad8400d4891">


## 💬리뷰 요구사항 및 논의할 거리(선택)

> - 리뷰어가 확인했으면 하는 부분이 있다면 작성해주세요

> - 구현 과정에서 팀 내 논의가 이뤄져야 할 부분이나 궁금하거나 알고 있어야 사항이 있다면 작성해주세요
