### PR TITLE
DNBackground 철자 수정 및 어워드 프레임 선택 시 스트로크 잘림 문제 수정

### DIFF
--- a/DeulLangNalLang/DeulLangNalLang.xcodeproj/project.pbxproj
+++ b/DeulLangNalLang/DeulLangNalLang.xcodeproj/project.pbxproj
@@ -498,7 +498,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"DeulLangNalLang/Preview Content\"";
-				DEVELOPMENT_TEAM = F8A6M6LNXL;
+				DEVELOPMENT_TEAM = 6G7PQ3DVAX;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = DeulLangNalLang/Info.plist;
@@ -515,7 +515,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.jwc.DeulLangNalLa;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jwc.DeulLangNalL;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -531,7 +531,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"DeulLangNalLang/Preview Content\"";
-				DEVELOPMENT_TEAM = F8A6M6LNXL;
+				DEVELOPMENT_TEAM = 6G7PQ3DVAX;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = DeulLangNalLang/Info.plist;
@@ -548,7 +548,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.jwc.DeulLangNalLa;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jwc.DeulLangNalL;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/DeulLangNalLang/DeulLangNalLang/Sources/Helper/Extensions/DNDesignSystem/Color.swift
+++ b/DeulLangNalLang/DeulLangNalLang/Sources/Helper/Extensions/DNDesignSystem/Color.swift
@@ -44,7 +44,7 @@ extension Color {
     static let DNDarkBlue = Color("DNDarkBlue")
     static let DNDarkGreen = Color("DNDarkGreen")
     static let DNGreen = Color("DNGreen")
-    static let DNBackGround = Color("DNBackGround")
+    static let DNBackground = Color("DNBackground")
     static let DNTabBarBlue = Color("DNTabBarBlue")
     
 }

--- a/DeulLangNalLang/DeulLangNalLang/Sources/View/BoastTab/AwardAddView.swift
+++ b/DeulLangNalLang/DeulLangNalLang/Sources/View/BoastTab/AwardAddView.swift
@@ -198,7 +198,7 @@ struct AwardAddView: View {
                         }
                     }
                 }
-                .frame(minHeight: 72)
+                .frame(maxHeight: 85)
                 .padding(.horizontal, 16)
             }
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) resolved: #이슈번호, #이슈번호, ...


## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- DNBackground 철자 오타로 인해 시뮬레이터가 안돌아가는 오류로 철자 수정이 이루어졌습니다.
- 어워드 프레임 선택 시 스트로크가 잘리는 문제가 있었는데, 맥스 하이트를 추가하여 스트로크가 잘리지 않도록 수정하였습니다.

### 스크린샷 (선택)


## 💬리뷰 요구사항 및 논의할 거리(선택)

> - 리뷰어가 확인했으면 하는 부분이 있다면 작성해주세요

> - 구현 과정에서 팀 내 논의가 이뤄져야 할 부분이나 궁금하거나 알고 있어야 사항이 있다면 작성해주세요
