### PR TITLE
자랑 추가 시, 화면 처음 렌더링 시 자랑 목록 안뜨는 이슈 해결

### DIFF
--- a/DeulLangNalLang/DeulLangNalLang/Sources/View/BoastTab/BoastMainView.swift
+++ b/DeulLangNalLang/DeulLangNalLang/Sources/View/BoastTab/BoastMainView.swift
@@ -18,6 +18,8 @@ struct BoastMainView: View {
     @Query(filter: #Predicate<Boast> { $0.award == nil && $0.writer == "류들" })
     var onlyDeulBoasts: [Boast]
     
+    @State var mode: BoastCategory = .both
+    
     var body: some View {
         TrackableScrollView(header: {
             ScrollView{
@@ -25,13 +27,16 @@ struct BoastMainView: View {
                     Spacer()
                     Menu {
                         Button("산이만 보기", action:{
-                            self.showingBoasts = onlySanBoasts
+                            self.mode = .onlySan
+                            updateShowingBoasts()
                         })
                         Button("들이만 보기", action:{
-                            self.showingBoasts = onlyDeulBoasts
+                            self.mode = .onlyDeul
+                            updateShowingBoasts()
                         })
                         Button("전체보기", action:{
-                            self.showingBoasts = bothBoasts
+                            self.mode = .both
+                            updateShowingBoasts()
                         })
                     } label: {
                         Image(systemName: "line.3.horizontal.decrease.circle")
@@ -47,7 +52,9 @@ struct BoastMainView: View {
                             .foregroundStyle(.black)
                             .font(.title1Regular)
                     }
-                    .sheet(isPresented: $showSheet) {
+                    .sheet(isPresented: $showSheet, onDismiss: {
+                        updateShowingBoasts()
+                    }) {
                         BoastAddView()
                     }
                 }
@@ -56,7 +63,7 @@ struct BoastMainView: View {
             }
             .padding()
         }, content: {
-            VStack(spacing: 0){
+            VStack(spacing: 0) {
                 ForEach($showingBoasts) { boast in
                     BoastCardView(boast: boast, onDelete: {
                         if let index = showingBoasts.firstIndex(of: boast.wrappedValue) {
@@ -65,6 +72,9 @@ struct BoastMainView: View {
                     })
                     .padding(.bottom, 16)
                 }
+            }
+            .onAppear {
+                updateShowingBoasts()
             }
         })
         .background(.dnBackground)
@@ -120,6 +130,23 @@ struct BoastMainView: View {
             .animation(.easeInOut, value: showHeader)
         }
     }
+    
+    private func updateShowingBoasts() {
+            switch mode {
+            case .both:
+                showingBoasts = bothBoasts
+            case .onlyDeul:
+                showingBoasts = onlyDeulBoasts
+            case .onlySan:
+                showingBoasts = onlySanBoasts
+            }
+        }
+}
+
+enum BoastCategory {
+    case both
+    case onlyDeul
+    case onlySan
 }
 
 #Preview {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) resolved: #이슈번호, #이슈번호, ...

close #106 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

 자랑 메인 View에서 처음 진입, 자랑 추가 후 렌더링 시 Boast Card들이 보이지 않던 이슈를 해결했습니다.

### 스크린샷 (선택)

![Simulator Screen Recording - iPhone 15 - 2024-05-24 at 02 01 25](https://github.com/DeveloperAcademy-POSTECH/2024-MC2-M16-DeulLangNalLang/assets/54929503/3f608f06-dfc8-4ace-b7a3-b46f27108509)


## 💬리뷰 요구사항 및 논의할 거리(선택)

> - 리뷰어가 확인했으면 하는 부분이 있다면 작성해주세요

> - 구현 과정에서 팀 내 논의가 이뤄져야 할 부분이나 궁금하거나 알고 있어야 사항이 있다면 작성해주세요
