### PR TITLE
이미지의 터치이벤트를 무시함

### DIFF
--- a/DeulLangNalLang/DeulLangNalLang/Sources/View/BoastTab/BoastCardView.swift
+++ b/DeulLangNalLang/DeulLangNalLang/Sources/View/BoastTab/BoastCardView.swift
@@ -24,6 +24,7 @@ struct BoastCardView: View {
                         .frame(height: 180, alignment: .center)
                         .clipShape(RoundedRectangle(cornerRadius: 8))
                         .clipped()
+                        .allowsHitTesting(false)
                 }
             }
             


### PR DESCRIPTION
- 이미지가 카드 위의 버튼영역까지 침범해서 버튼이 안눌리는 에러 해결

## #️⃣연관된 이슈

> ex) resolved: #이슈번호, #이슈번호, ...


## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

`.allowsHitTesting(false)` 코드 추가


## 💬리뷰 요구사항 및 논의할 거리(선택)

> - 리뷰어가 확인했으면 하는 부분이 있다면 작성해주세요

> - 구현 과정에서 팀 내 논의가 이뤄져야 할 부분이나 궁금하거나 알고 있어야 사항이 있다면 작성해주세요
